### PR TITLE
Add an HTTP Endpoint

### DIFF
--- a/example.py
+++ b/example.py
@@ -23,7 +23,7 @@ with ExampleCommands(sys.argv[1]) as examples:
     time.sleep(10)
 
     print("write hello world")
-    examples.hello_world()
+    examples.draw_text("HELLO, WORLD")
     time.sleep(10)
 
     print("scrolling")

--- a/example_commands.py
+++ b/example_commands.py
@@ -48,8 +48,8 @@ class ExampleCommands(DivoomAdapter):
         for i in range(0, len(pkgs)):
             self.device.send(pkgs[i])
 
-    def hello_world(self):
-        img = divoom_image.draw_text_to_image(text="HELLO WORLD", color=divoom_image.BMP_YELLOW, size=(70, 10))
+    def draw_text(self, text="HELLO WORLD"):
+        img = divoom_image.draw_text_to_image(text=text, color=divoom_image.BMP_YELLOW, size=(70, 10))
         sliced_images = divoom_image.horizontal_slices(img)
         # create divoom packages
         raw_data_packages = []

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ class S(BaseHTTPRequestHandler):
 
         length = int(self.headers["content-length"])
         payload = self.rfile.read(length)
-        data = json.loads(payload)
+        data = json.loads(payload.decode("utf-8"))
 
         action = data["action"]
         value = data["value"]

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ class S(BaseHTTPRequestHandler):
         query_params = parse_qs(urlparse(self.path).query)
         print(query_params)
         self._set_divoom()
-        show_files(self.protocol, self.device, [query_params["filename"]], 10)
+        show_files(self.protocol, self.device, [query_params["filename"][0]], 10)
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ class S(BaseHTTPRequestHandler):
         query_params = parse_qs(urlparse(self.path).query)
         print(query_params)
         self._set_divoom()
-        show_files(self.protocol, self.device, [query_params.filename], 10)
+        show_files(self.protocol, self.device, [query_params["filename"]], 10)
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -36,9 +36,4 @@ def run(server_class=HTTPServer, handler_class=S, port=1989):
 
 
 if __name__ == "__main__":
-    from sys import argv
-
-    if len(argv) == 2:
-        run(port=int(argv[1]))
-    else:
-        run()
+    run()

--- a/server.py
+++ b/server.py
@@ -21,10 +21,16 @@ class S(BaseHTTPRequestHandler):
         self._set_headers()
         self.wfile.write("got".encode("utf-8"))
         query_params = parse_qs(urlparse(self.path).query)
-        print(query_params)
         self._set_divoom()
+
+        action = query_params["action"][0]
+        value = query_params["value"][0]
+
         with self.commands as commands:
-            commands.show_file(query_params["filename"][0])
+            if (action == "show_file"):
+                commands.show_file(value)
+            elif (action == "draw_text"):
+                commands.draw_text(value)
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -12,9 +12,21 @@ class S(BaseHTTPRequestHandler):
         if not hasattr(self, "commands"):
             self.commands = ExampleCommands(argv[1])
 
+    def do_OPTIONS(self):
+        self.send_response(200, "ok")
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
     def _set_headers(self):
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
 
     def do_GET(self):

--- a/server.py
+++ b/server.py
@@ -1,0 +1,39 @@
+# base httpserver example from...
+# https://gist.github.com/bradmontgomery/2219997
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class S(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_headers()
+        self.wfile.write("got".encode("utf-8"))
+
+    def do_POST(self):
+        # Doesn't do anything with posted data
+        self._set_headers()
+        self.wfile.write("posted".encode("utf-8"))
+
+    def do_HEAD(self):
+        self._set_headers()
+
+
+def run(server_class=HTTPServer, handler_class=S, port=1989):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print
+    'Starting httpd...'
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    from sys import argv
+
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()

--- a/server.py
+++ b/server.py
@@ -38,6 +38,8 @@ class S(BaseHTTPRequestHandler):
                 commands.show_file(value)
             elif action == "draw_text":
                 commands.draw_text(value)
+            elif action == "show_pixel_array":
+                commands.show_pixel_array(value)
 
     def do_HEAD(self):
         self._set_headers()

--- a/server.py
+++ b/server.py
@@ -24,7 +24,7 @@ class S(BaseHTTPRequestHandler):
         print(query_params)
         self._set_divoom()
         with self.commands as commands:
-            commands.show_files([query_params["filename"][0]], 10)
+            commands.show_file(query_params["filename"][0])
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -4,18 +4,13 @@
 from sys import argv
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
-from example import show_files
-import divoom_protocol
-import divoom_device
+from example_commands import ExampleCommands
 
 class S(BaseHTTPRequestHandler):
 
     def _set_divoom(self):
-        if not hasattr(self, "protocol"):
-            self.protocol = divoom_protocol.DivoomAuraBoxProtocol()
-            self.device = divoom_device.DivoomDevice(argv[1])
-
-            self.device.connect()
+        if not hasattr(self, "commands"):
+            self.commands = ExampleCommands(argv[1])
 
     def _set_headers(self):
         self.send_response(200)
@@ -28,7 +23,8 @@ class S(BaseHTTPRequestHandler):
         query_params = parse_qs(urlparse(self.path).query)
         print(query_params)
         self._set_divoom()
-        show_files(self.protocol, self.device, [query_params["filename"][0]], 10)
+        with self.commands as commands:
+            commands.show_files([query_params["filename"][0]], 10)
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -2,6 +2,8 @@
 # https://gist.github.com/bradmontgomery/2219997
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+from example import show_files
 
 class S(BaseHTTPRequestHandler):
     def _set_headers(self):
@@ -12,6 +14,9 @@ class S(BaseHTTPRequestHandler):
     def do_GET(self):
         self._set_headers()
         self.wfile.write("got".encode("utf-8"))
+        query_params = parse_qs(urlparse(self.path).query)
+        print(query_params)
+        show_files([query_params.filename], 10)
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -10,11 +10,12 @@ import divoom_device
 
 class S(BaseHTTPRequestHandler):
 
-    def __init__(self):
-        self.protocol = divoom_protocol.DivoomAuraBoxProtocol()
-        self.device = divoom_device.DivoomDevice(argv[1])
+    def _set_divoom(self):
+        if not self.protocol:
+            self.protocol = divoom_protocol.DivoomAuraBoxProtocol()
+            self.device = divoom_device.DivoomDevice(argv[1])
 
-        self.device.connect()
+            self.device.connect()
 
     def _set_headers(self):
         self.send_response(200)
@@ -26,6 +27,7 @@ class S(BaseHTTPRequestHandler):
         self.wfile.write("got".encode("utf-8"))
         query_params = parse_qs(urlparse(self.path).query)
         print(query_params)
+        self._set_divoom()
         show_files(self.protocol, self.device, [query_params.filename], 10)
 
     def do_POST(self):

--- a/server.py
+++ b/server.py
@@ -1,11 +1,21 @@
 # base httpserver example from...
 # https://gist.github.com/bradmontgomery/2219997
 
+from sys import argv
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 from example import show_files
+import divoom_protocol
+import divoom_device
 
 class S(BaseHTTPRequestHandler):
+
+    def __init__(self):
+        self.protocol = divoom_protocol.DivoomAuraBoxProtocol()
+        self.device = divoom_device.DivoomDevice(argv[1])
+
+        self.device.connect()
+
     def _set_headers(self):
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
@@ -16,7 +26,7 @@ class S(BaseHTTPRequestHandler):
         self.wfile.write("got".encode("utf-8"))
         query_params = parse_qs(urlparse(self.path).query)
         print(query_params)
-        show_files([query_params.filename], 10)
+        show_files(self.protocol, self.device, [query_params.filename], 10)
 
     def do_POST(self):
         # Doesn't do anything with posted data

--- a/server.py
+++ b/server.py
@@ -3,8 +3,8 @@
 
 from sys import argv
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from urllib.parse import urlparse, parse_qs
 from example_commands import ExampleCommands
+import json
 
 class S(BaseHTTPRequestHandler):
 
@@ -20,22 +20,24 @@ class S(BaseHTTPRequestHandler):
     def do_GET(self):
         self._set_headers()
         self.wfile.write("got".encode("utf-8"))
-        query_params = parse_qs(urlparse(self.path).query)
-        self._set_divoom()
-
-        action = query_params["action"][0]
-        value = query_params["value"][0]
-
-        with self.commands as commands:
-            if (action == "show_file"):
-                commands.show_file(value)
-            elif (action == "draw_text"):
-                commands.draw_text(value)
 
     def do_POST(self):
-        # Doesn't do anything with posted data
         self._set_headers()
         self.wfile.write("posted".encode("utf-8"))
+        self._set_divoom()
+
+        length = int(self.headers["content-length"])
+        payload = self.rfile.read(length)
+        data = json.loads(payload)
+
+        action = data["action"]
+        value = data["value"]
+
+        with self.commands as commands:
+            if action == "show_file":
+                commands.show_file(value)
+            elif action == "draw_text":
+                commands.draw_text(value)
 
     def do_HEAD(self):
         self._set_headers()

--- a/server.py
+++ b/server.py
@@ -11,7 +11,7 @@ import divoom_device
 class S(BaseHTTPRequestHandler):
 
     def _set_divoom(self):
-        if not self.protocol:
+        if not hasattr(self, "protocol"):
             self.protocol = divoom_protocol.DivoomAuraBoxProtocol()
             self.device = divoom_device.DivoomDevice(argv[1])
 


### PR DESCRIPTION
- Expose Divoom example commands as a `/get` endpoint
- Accepts parameters `action` and `value`

### Sample Requests

Write scrolling text to the Divoom...

```
curl -X POST \
  http://192.168.1.241:1989/ \
  -H 'content-type: application/json' \
  -d '{
	"action": "draw_text",
	"value": "hello world"
}'
```

Use our custom Pixel Array format...

```
curl -X POST \
  http://192.168.1.241:1989/ \
  -H 'content-type: application/json' \
  -d '{
	"action": "show_pixel_array",
	"value": [
            0, 0, 0, 0, 0, 0, 0, 0, 6, 0,
            0, 0, 0, 0, 0, 0, 0, 6, 6, 0,
            0, 0, 0, 0, 0, 0, 0, 6, 6, 0,
            0, 0, 0, 0, 0, 0, 6, 6, 6, 0,
            0, 0, 0, 0, 0, 6, 6, 6, 6, 0,
            0, 0, 0, 0, 6, 6, 6, 6, 6, 0,
            0, 0, 0, 0, 0, 6, 6, 6, 6, 0,
            0, 0, 0, 6, 0, 0, 6, 6, 6, 0,
            0, 0, 6, 6, 0, 0, 6, 6, 6, 0,
            0, 6, 6, 6, 0, 0, 0, 6, 6, 0
        ]
    }'
```